### PR TITLE
add inline ?! type and documentation tweaks

### DIFF
--- a/questionable/results.nim
+++ b/questionable/results.nim
@@ -20,11 +20,21 @@ export withoutresult
 type ResultFailure* = object of CatchableError
 
 template `?!`*(T: typed): type Result[T, ref CatchableError] =
-  ## Use `?!` make a Result type. These Result types either hold a value or
-  ## an error. For example the type `?!int` is short for
-  ## `Result[int, ref CatchableError]`.
+  ## Use `?!` to declare a Result type for `T` with an error of `ref CatchableError`.
+  ## 
+  ## Result types either hold a value or an error. For example
+  ## the type `?!int` is short for `Result[int, ref CatchableError]`.
+  ## 
 
   Result[T, ref CatchableError]
+
+template `?!`*[T; E: CatchableError](t: typedesc[T], e: typedesc[E]): type Result[T, ref E] =
+  ## Use inline `?!` to declare a Result type for `T` with a given error type.
+  ## 
+  ## Result types either hold a value or an error. For example
+  ## the type `string ?! KeyError` is short for `Result[string, ref KeyError]`.
+  ## 
+  Result[T, ref E]
 
 template `!`*[T](value: ?!T): T =
   ## Returns the value of a Result when you're absolutely sure that it

--- a/questionable/withoutresult.nim
+++ b/questionable/withoutresult.nim
@@ -22,7 +22,7 @@ macro without*(condition, errorname, body: untyped): untyped =
   ## Used to place guards that ensure that a Result contains a value.
   ## Exposes error when Result does not contain a value.
   
-  let errorIdent = ident errorname.strVal
+  let errorIdent = ident errorname.repr
 
   # Nim's early symbol resolution might have picked up a symbol with the
   # same name as our error variable. We need to undo this to make sure that our

--- a/questionable/withoutresult.nim
+++ b/questionable/withoutresult.nim
@@ -22,7 +22,7 @@ macro without*(condition, errorname, body: untyped): untyped =
   ## Used to place guards that ensure that a Result contains a value.
   ## Exposes error when Result does not contain a value.
   
-  let errorIdent = ident $errorname
+  let errorIdent = ident errorname.strVal
 
   # Nim's early symbol resolution might have picked up a symbol with the
   # same name as our error variable. We need to undo this to make sure that our

--- a/questionable/withoutresult.nim
+++ b/questionable/withoutresult.nim
@@ -22,7 +22,6 @@ macro without*(condition, errorname, body: untyped): untyped =
   ## Used to place guards that ensure that a Result contains a value.
   ## Exposes error when Result does not contain a value.
   
-  errorname.expectKind(nnkIdent)
   let errorIdent = ident $errorname
 
   # Nim's early symbol resolution might have picked up a symbol with the

--- a/questionable/withoutresult.nim
+++ b/questionable/withoutresult.nim
@@ -21,7 +21,8 @@ proc undoSymbolResolution(expression, ident: NimNode): NimNode =
 macro without*(condition, errorname, body: untyped): untyped =
   ## Used to place guards that ensure that a Result contains a value.
   ## Exposes error when Result does not contain a value.
-
+  
+  errorname.expectKind(nnkIdent)
   let errorIdent = ident $errorname
 
   # Nim's early symbol resolution might have picked up a symbol with the


### PR DESCRIPTION
Adds an inline `?!` type to enable this: 

```nim
proc setupKey*(path: string): PrivateKey ?! CodexKeyError = discard
```

Equivalent to:

```nim
proc setupKey*(path: string): Result[PrivateKey, CodexKeyError] = discard
```

