### PR TITLE
Fix tests for stew with Nim < 1.6

### DIFF
--- a/testmodules/stew/test.nimble
+++ b/testmodules/stew/test.nimble
@@ -3,7 +3,11 @@ author = "Questionable Authors"
 description = "Questionable tests for pkg/stew"
 license = "MIT"
 
-requires "stew"
+when (NimMajor, NimMinor) >= (1, 6):
+  requires "stew"
 
-task test, "Runs the test suite":
-  exec "nim c -f -r --skipParentCfg test.nim"
+  task test, "Runs the test suite":
+    exec "nim c -f -r --skipParentCfg test.nim"
+else:
+  task test, "Runs the test suite":
+    echo "Warning: Skipping test with stew on Nim < 1.6"


### PR DESCRIPTION
`stew` now requires a Nim >= 1.6, so this disables testing stew with earlier Nim versions.

Fixes #37 