### PR TITLE
Better compilation error when calling `without` with wrong parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nim: [stable, 1.4.8, 1.2.18]
+        nim: [stable, 1.6.14, 1.4.8, 1.2.18]
     steps:
     - uses: actions/checkout@v2
     - uses: iffy/install-nim@v3

--- a/questionable/withoutresult.nim
+++ b/questionable/withoutresult.nim
@@ -2,12 +2,13 @@ import std/macros
 import ./without
 import ./private/binderror
 
+const symbolKinds = {nnkSym, nnkOpenSymChoice, nnkClosedSymChoice}
+const identKinds = {nnkIdent} + symbolKinds
+
 proc undoSymbolResolution(expression, ident: NimNode): NimNode =
   ## Finds symbols in the expression that match the `ident` and replaces them
   ## with `ident`, effectively undoing any symbol resolution that happened
   ## before.
-
-  const symbolKinds = {nnkSym, nnkOpenSymChoice, nnkClosedSymChoice}
 
   if expression.kind in symbolKinds and eqIdent($expression, $ident):
     return ident
@@ -21,6 +22,9 @@ proc undoSymbolResolution(expression, ident: NimNode): NimNode =
 macro without*(condition, errorname, body: untyped): untyped =
   ## Used to place guards that ensure that a Result contains a value.
   ## Exposes error when Result does not contain a value.
+
+  if errorname.kind notin identKinds:
+    error("expected an identifier, got " & errorname.repr, errorname)
 
   let errorIdent = ident $errorname
 


### PR DESCRIPTION
Give a better compiler error when calling `without` with an error identifier that is not an identifier.

This can happen when a user types something like this:
```nim
without foo =? bar(), error + 1: # "error + 1" is not an identifier
  discard
```

Or when a template is evaluated before the `without` macro is evaluated:
```nim
template err =
  "some string"

without foo =? bar(), err: # "some string" is not an identifier
  discard
```

Fixes #39 