### PR TITLE
Indexing of strings and sequences should not catch Defect

### DIFF
--- a/questionable/indexing.nim
+++ b/questionable/indexing.nim
@@ -1,7 +1,16 @@
 import std/macros
 
-when (NimMajor, NimMinor) < (1, 4):
-  type IndexDefect = IndexError
+macro `.?`*(expression: seq | string, brackets: untyped{nkBracket}): untyped =
+  # chain is of shape: (seq or string).?[index]
+  let index = brackets[0]
+  quote do:
+    block:
+      type T = typeof(`expression`[`index`])
+      let evaluated = `expression`
+      if `index` < evaluated.len:
+        evaluated[`index`].some
+      else:
+        T.none
 
 macro `.?`*(expression: typed, brackets: untyped{nkBracket}): untyped =
   # chain is of shape: expression.?[index]
@@ -12,6 +21,4 @@ macro `.?`*(expression: typed, brackets: untyped{nkBracket}): untyped =
       try:
         `expression`[`index`].some
       except KeyError:
-        T.none
-      except IndexDefect:
         T.none


### PR DESCRIPTION
Fixes issue as indicated by @arnetheduck  in https://github.com/codex-storage/questionable/pull/42#discussion_r1283134645

Replaces the attempt to catch a `Defect` with a length pre-check.