### PR TITLE
Fix compilation issue with Nim 1.6.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nim: [stable, 1.6.14, 1.4.8, 1.2.18]
+        nim: [stable, 1.6.16, 1.4.8, 1.2.18]
     steps:
     - uses: actions/checkout@v2
     - uses: iffy/install-nim@v3

--- a/questionable/binding.nim
+++ b/questionable/binding.nim
@@ -8,7 +8,7 @@ proc option[T](option: Option[T]): Option[T] =
 proc placeholder(T: type): T =
   discard
 
-template bindLet(name, expression): bool =
+template bindLet(name, expression): untyped =
   let evaluated = expression
   let option = evaluated.option
   type T = typeof(option.unsafeGet())
@@ -19,7 +19,7 @@ template bindLet(name, expression): bool =
     placeholder(T)
   option.isSome
 
-template bindVar(name, expression): bool =
+template bindVar(name, expression): untyped =
   let evaluated = expression
   let option = evaluated.option
   type T = typeof(option.unsafeGet())


### PR DESCRIPTION
Fixes #48

Works around https://github.com/nim-lang/Nim/issues/22897 by changing return type of template to `untyped`.