### PR TITLE
Improve the `=?` operator

### DIFF
--- a/questionable/binding.nim
+++ b/questionable/binding.nim
@@ -45,9 +45,9 @@ proc newUnpackTupleNode(names: NimNode, value: NimNode): NimNode =
   nnkLetSection.newTree(vartuple)
 
 macro bindTuple(names, expression): bool =
-  let opt = ident("option")
-  let evaluated = ident("evaluated")
-  let T = ident("T")
+  let opt = genSym(nskLet, "option")
+  let evaluated = genSym(nskLet, "evaluated")
+  let T = genSym(nskType, "T")
 
   let value = quote do:
     if `opt`.isSome:

--- a/testmodules/options/test.nim
+++ b/testmodules/options/test.nim
@@ -165,6 +165,53 @@ suite "optionals":
     else:
       fail()
 
+  test "=? works with reference types":
+    var x = new int
+    x[] = 42
+    if a =? x:
+      check a[] == 42
+    else:
+      fail
+
+    x = nil
+    if a =? x:
+      fail
+
+    var p = proc = discard
+    if a =? p:
+      a()
+    else:
+      fail
+
+    p = nil
+    if a =? p:
+      fail
+
+  test "=? rejects non-reference types":
+    check `not` compiles do:
+      if a =? 0:
+        discard
+    check `not` compiles do:
+      if var a =? 0:
+        discard
+    check `not` compiles do:
+      if (a,) =? (0,):
+        discard
+
+  test "=? works with custom optional types":
+    type MyOption = distinct int
+    proc isSome(x: MyOption): bool = x.int >= 0
+    proc unsafeGet(x: MyOption): int = x.int
+    template toOption(x: MyOption): MyOption = x
+
+    if a =? MyOption 42:
+      check a == 42
+    else:
+      fail
+
+    if a =? MyOption -1:
+      fail
+
   test "=? binds and unpacks tuples":
     if (a, b) =? (some ("test", 1)):
       check a == "test"

--- a/testmodules/options/test.nim
+++ b/testmodules/options/test.nim
@@ -288,6 +288,15 @@ suite "optionals":
     else:
       fail()
 
+  test "=? for tuples does not leak symbols into caller's scope":
+    const evaluated = ""
+    type T = string
+    if (a,) =? some (0,):
+      check a == 0
+      check option is proc
+      check evaluated is string
+      check T is string
+
   test "without statement can be used for early returns":
     proc test1 =
       without a =? 42.some:


### PR DESCRIPTION
1.  Accept only optional and reference types as RHS of `=?`.

    Motivation: I had roughly this code, simplified:

    ```nim
    type Id = distinct Natural
    var transitionIds: seq[?Id]
    # ...
    if id =? transitionIds[x]:
      discard # Use `id`.
    else:
      discard # Create a new object.
    ```

    After refactoring, it turned into this:

    ```nim
    type OptId = distinct int32 # `-1` for `none`.
    var transitionIds: seq[OptId]
    # ...
    if id =? transitionIds[x]:
      discard # Use `id`.
    else:
      discard # Create a new object.
    ```

    And… it continued to compile! The _else_ branch suddenly became dead code.

    This commit fixes the issue. (The snippet above will produce a compilation error.)

2.  Create identifiers with `genSym`.

    `genSym`, as opposed to `ident`, introduces a fresh symbol, which cannot leak into user’s scope.
