### PR TITLE
Reference types are handled by `without` statement with error

### DIFF
--- a/questionable/private/binderror.nim
+++ b/questionable/private/binderror.nim
@@ -21,8 +21,17 @@ macro captureBindError*(error: var ref CatchableError, expression): auto =
     # return the evaluated result
     evaluated
 
-func error[T](option: Option[T]): ref CatchableError =
+func error[T](_: Option[T]): ref CatchableError =
   newException(ValueError, "Option is set to `none`")
+
+func error[T](_: ref T): ref CatchableError =
+  newException(ValueError, "ref is nil")
+
+func error[T](_: ptr T): ref CatchableError =
+  newException(ValueError, "ptr is nil")
+
+func error[Proc: proc | iterator](_: Proc): ref CatchableError =
+  newException(ValueError, "proc or iterator is nil")
 
 macro bindFailed*(expression: typed) =
   ## Called when a binding (=?) fails.

--- a/testmodules/results/test.nim
+++ b/testmodules/results/test.nim
@@ -326,6 +326,48 @@ suite "result":
     test1()
     test2()
 
+  test "without statement with error handles references as well":
+    proc test =
+      var x: ref int = nil
+      without a =? x, error:
+        check error.msg == "ref is nil"
+        return
+      fail
+
+    test()
+
+  test "without statement with error handles pointers as well":
+    proc test =
+      var x: ptr int = nil
+      without a =? x, error:
+        check error.msg == "ptr is nil"
+        return
+      fail
+
+    test()
+
+  test "without statement with error handles closures as well":
+    proc test =
+      var x = proc = discard
+      x = nil
+      without a =? x, error:
+        check error.msg == "proc or iterator is nil"
+        return
+      fail
+
+    test()
+
+  test "without statement with error handles iterators as well":
+    when (NimMajor, NimMinor) != (2, 0):
+      proc test =
+        var x: iterator: int = nil
+        without a =? x, error:
+          check error.msg == "proc or iterator is nil"
+          return
+        fail
+
+      test()
+
   test "without statement with error can be used more than once":
     proc test =
       without a =? 42.success, error:


### PR DESCRIPTION
Support for reference types (ref | ptr | proc | iterator) was added in #50.

This PR allows the use of reference types in expressions like this: `without value =? reference, error`