### PR TITLE
Fix: `without` should work when `$` has side effects

### DIFF
--- a/questionable/private/binderror.nim
+++ b/questionable/private/binderror.nim
@@ -21,16 +21,16 @@ macro captureBindError*(error: var ref CatchableError, expression): auto =
     # return the evaluated result
     evaluated
 
-func error[T](_: Option[T]): ref CatchableError =
+func unsafeError[T](_: Option[T]): ref CatchableError =
   newException(ValueError, "Option is set to `none`")
 
-func error[T](_: ref T): ref CatchableError =
+func unsafeError[T](_: ref T): ref CatchableError =
   newException(ValueError, "ref is nil")
 
-func error[T](_: ptr T): ref CatchableError =
+func unsafeError[T](_: ptr T): ref CatchableError =
   newException(ValueError, "ptr is nil")
 
-func error[Proc: proc | iterator](_: Proc): ref CatchableError =
+func unsafeError[Proc: proc | iterator](_: Proc): ref CatchableError =
   newException(ValueError, "proc or iterator is nil")
 
 macro bindFailed*(expression: typed) =
@@ -49,4 +49,4 @@ macro bindFailed*(expression: typed) =
       # check that the error variable is in scope
       when compiles(`errorVariable`):
         # assign bind error to error variable
-        `errorVariable` = `expression`.error
+        `errorVariable` = `expression`.unsafeError

--- a/testmodules/results/test.nim
+++ b/testmodules/results/test.nim
@@ -643,6 +643,19 @@ suite "result":
     someProc(42.success)
     someProc(int.failure "some error")
 
+type TypeWithSideEffect = object
+proc `$`*(value: TypeWithSideEffect): string {.sideEffect.} =
+  discard
+
+suite "result side effects":
+
+  test "without statement with error works when `$` has side effects":
+    proc foo =
+      without x =? TypeWithSideEffect.failure("error"), error:
+        discard error
+        return
+      fail()
+    foo()
 
 import pkg/questionable/resultsbase
 


### PR DESCRIPTION
When a type has a `$` proc that might produce side effects, then a `without` statement that tries to bind this type fails with a compilation error:
```
results.nim(373, 6) Error: 'raiseResultDefect' can have side effects
```

This fix avoids invoking the `raiseResultDefect` func by using `.unsafeError` instead of `.error` . It's ok to use `unsafeError` in `bindFailed`, because we've already checked that the result contains an error.