### PR TITLE
`without` with error variable works for any Result type

### DIFF
--- a/questionable/private/binderror.nim
+++ b/questionable/private/binderror.nim
@@ -21,16 +21,16 @@ macro captureBindError*(error: var ref CatchableError, expression): auto =
     # return the evaluated result
     evaluated
 
-func unsafeError[T](_: Option[T]): ref CatchableError =
+func unsafeCatchableError[T](_: Option[T]): ref CatchableError =
   newException(ValueError, "Option is set to `none`")
 
-func unsafeError[T](_: ref T): ref CatchableError =
+func unsafeCatchableError[T](_: ref T): ref CatchableError =
   newException(ValueError, "ref is nil")
 
-func unsafeError[T](_: ptr T): ref CatchableError =
+func unsafeCatchableError[T](_: ptr T): ref CatchableError =
   newException(ValueError, "ptr is nil")
 
-func unsafeError[Proc: proc | iterator](_: Proc): ref CatchableError =
+func unsafeCatchableError[Proc: proc | iterator](_: Proc): ref CatchableError =
   newException(ValueError, "proc or iterator is nil")
 
 macro bindFailed*(expression: typed) =
@@ -49,4 +49,4 @@ macro bindFailed*(expression: typed) =
       # check that the error variable is in scope
       when compiles(`errorVariable`):
         # assign bind error to error variable
-        `errorVariable` = `expression`.unsafeError
+        `errorVariable` = `expression`.unsafeCatchableError

--- a/questionable/results.nim
+++ b/questionable/results.nim
@@ -123,6 +123,18 @@ template toOption*[T, E](value: Result[T, E]): ?T =
 
   value.option
 
+proc unsafeCatchableError*[T, E](value: Result[T, E]): ref CatchableError =
+  ## Returns the error from the Result, converted to `ref CatchableError` if
+  ## necessary. Behaviour is undefined when the result holds a value instead of
+  ## an error.
+  when E is ref CatchableError:
+    value.unsafeError
+  else:
+    when compiles($value.unsafeError):
+      newException(ResultFailure, $value.unsafeError)
+    else:
+      newException(ResultFailure, "Result is an error")
+
 proc errorOption*[T, E](value: Result[T, E]): ?E =
   ## Returns an Option that contains the error from the Result, if it has one.
 

--- a/testmodules/results/test.nim
+++ b/testmodules/results/test.nim
@@ -663,7 +663,7 @@ suite "result compatibility":
 
   type R = Result[int, string]
   let good = R.ok 42
-  let bad = R.err "error"
+  let bad = R.err "some error"
 
   test "|?, =? and .option work on other types of Result":
     check bad |? 43 == 43
@@ -681,3 +681,13 @@ suite "result compatibility":
       fail
     without b =? good:
       fail
+
+  test "without statement with error works on other type of Result":
+    without value =? bad, error:
+      check error of ResultFailure
+      check error.msg == "some error"
+
+  test "without statement with error works on Result[T, void]":
+    without value =? Result[int, void].err, error:
+      check error of ResultFailure
+      check error.msg == "Result is an error"


### PR DESCRIPTION
These type of statements used to only work for `?!T` types:

```nim
without x =? y, error:
  # do something with error
```

Now they also work for any `Result[T, E]` types, with the caveat that the error is converted to a ref CatchableError.
Conversion is necessary, because we need a type for the error variable that works for any type of result, in case that we have multiple `=?` bindings in the `without` expression, e.g.:

```nim
var a: ?!int
var b: Result[int, string]

without x =? a and y =? b, error:
  # without conversion error types would clash
```
